### PR TITLE
add Dockerfile

### DIFF
--- a/Docker-Makefile
+++ b/Docker-Makefile
@@ -1,0 +1,62 @@
+# https://github.com/Miroka96/docker-makefile
+
+NAME = hyrise/opossum
+TAG = 1.0
+
+VOLUME = ${PWD}
+MOUNTPATH = /project
+
+#LOCALPORT = 8080
+#CONTAINERPORT = 80
+
+# if you want a special image name, edit this
+IMAGE = $(NAME):$(TAG)
+
+# if you have no volume, delete the right part
+VOLUMEMOUNTING = -v $(VOLUME):$(MOUNTPATH)
+
+# if you publish no ports, delete the right part
+PORTPUBLISHING = #-p $(LOCALPORT):$(CONTAINERPORT)
+
+.PHONY: build test test-shell build-test deploy build-deploy undeploy redeploy build-redeploy clean-volume clean clean install-dependencies configure
+
+build:
+	docker build -t $(IMAGE) .
+
+build-nocache:
+	docker build -t $(IMAGE) --no-cache .
+
+test:
+	docker run $(VOLUMEMOUNTING) $(PORTPUBLISHING) --rm $(IMAGE)
+
+test-shell:
+	docker run -it $(VOLUMEMOUNTING) $(PORTPUBLISHING) --rm $(IMAGE) /bin/bash
+
+build-test: build test
+
+deploy:
+	docker run --detach --restart always --name=$(NAME) $(VOLUMEMOUNTING) $(PORTPUBLISHING) $(IMAGE)
+
+build-deploy: build deploy
+
+undeploy:
+	-docker stop $(NAME)
+	docker rm $(NAME)
+
+redeploy: undeploy deploy
+
+build-redeploy: build redeploy
+
+clean-volume:
+	-docker volume rm $(VOLUME)
+
+clean:
+	-docker rm $(NAME)
+
+clean: clean-volume clean
+
+install-dependencies:
+	echo No dependencies yet
+
+configure:
+	echo No configuration yet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:16.04
+MAINTAINER Mirko Krause <mirko.krause@student.hpi.de>
+
+RUN mkdir /project
+
+COPY . /project
+
+WORKDIR /project
+
+ENV OPOSSUM_HEADLESS_SETUP true
+RUN apt-get update \
+	&& apt-get install -y \
+	sudo \
+	software-properties-common \
+	&& add-apt-repository -y ppa:git-core/ppa \
+	&& apt-get update \
+	&& apt-get install -y git \
+	&& chmod +x install.sh #\
+	&& ./install.sh \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME /project
+
+CMD echo give me a command


### PR DESCRIPTION
The install-script is not usable on Fedora, because the package manager is dnf/yum, therefore a docker container seems nice.

build the docker container using:
make -f Docker-Makefile build

Some dependencies for the install.sh-script have been strange, for example git... So I wanted to make this step easier for others.
